### PR TITLE
Do not quote schema names in non-standard case

### DIFF
--- a/src/main/java/liquibase/ext/bigquery/database/BigqueryDatabase.java
+++ b/src/main/java/liquibase/ext/bigquery/database/BigqueryDatabase.java
@@ -10,6 +10,9 @@ import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.statement.core.GetViewDefinitionStatement;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -87,6 +90,13 @@ public class BigqueryDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
         return PRODUCT_NAME.trim().equalsIgnoreCase(conn.getDatabaseProductName().trim());
+    }
+    @Override
+    public String escapeObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
+        if (objectType.equals(Schema.class) || objectType.equals(Catalog.class)) {
+            return objectName;
+        }
+        return super.escapeObjectName(objectName, objectType);
     }
 
     @Override

--- a/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryDatasetSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryDatasetSnapshotGenerator.java
@@ -25,7 +25,7 @@ public class BigQueryDatasetSnapshotGenerator extends SchemaSnapshotGenerator {
     @Override
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
         int priority = super.getPriority(objectType, database);
-        if (database instanceof BigqueryDatabase) {
+        if (priority > PRIORITY_NONE && database instanceof BigqueryDatabase) {
             priority += PRIORITY_DATABASE;
         }
         return priority;

--- a/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQuerySequenceSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQuerySequenceSnapshotGenerator.java
@@ -17,7 +17,7 @@ public class BigQuerySequenceSnapshotGenerator extends SequenceSnapshotGenerator
         @Override
         public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
             int priority = super.getPriority(objectType, database);
-            if (database instanceof BigqueryDatabase) {
+            if (priority > PRIORITY_NONE && database instanceof BigqueryDatabase) {
                 priority += PRIORITY_DATABASE;
             }
             return priority;

--- a/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryUniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryUniqueConstraintSnapshotGenerator.java
@@ -23,7 +23,7 @@ public class BigQueryUniqueConstraintSnapshotGenerator extends UniqueConstraintS
     @Override
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
         int priority = super.getPriority(objectType, database);
-        if (database instanceof BigqueryDatabase) {
+        if (priority > PRIORITY_NONE && database instanceof BigqueryDatabase) {
             priority += PRIORITY_DATABASE;
         }
         return priority;

--- a/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryViewSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryViewSnapshotGenerator.java
@@ -6,6 +6,7 @@ import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
+import liquibase.ext.bigquery.database.BigqueryDatabase;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.jvm.ViewSnapshotGenerator;
 import liquibase.statement.core.RawSqlStatement;
@@ -22,10 +23,13 @@ import static liquibase.ext.bigquery.database.BigqueryDatabase.BIGQUERY_PRIORITY
 public class BigQueryViewSnapshotGenerator extends ViewSnapshotGenerator {
 
 
-    public int getPriority() {
-        return BIGQUERY_PRIORITY_DATABASE;
-    }
-
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        int priority = super.getPriority(objectType, database);
+        if (priority > PRIORITY_NONE && database instanceof BigqueryDatabase) {
+            priority += PRIORITY_DATABASE;
+        }
+        return priority;    }
 
     @Override
     protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException {

--- a/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryViewSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryViewSnapshotGenerator.java
@@ -18,8 +18,6 @@ import liquibase.util.StringUtil;
 import java.util.List;
 import java.util.Map;
 
-import static liquibase.ext.bigquery.database.BigqueryDatabase.BIGQUERY_PRIORITY_DATABASE;
-
 public class BigQueryViewSnapshotGenerator extends ViewSnapshotGenerator {
 
 
@@ -29,7 +27,8 @@ public class BigQueryViewSnapshotGenerator extends ViewSnapshotGenerator {
         if (priority > PRIORITY_NONE && database instanceof BigqueryDatabase) {
             priority += PRIORITY_DATABASE;
         }
-        return priority;    }
+        return priority;
+    }
 
     @Override
     protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException {
@@ -41,31 +40,27 @@ public class BigQueryViewSnapshotGenerator extends ViewSnapshotGenerator {
 
             CatalogAndSchema catalogAndSchema = (new CatalogAndSchema(schema.getCatalogName(), schema.getName())).customize(database);
             String jdbcSchemaName = database.correctObjectName(((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema), Schema.class);
-            String query = String.format("SELECT view_definition FROM " + jdbcSchemaName + "." + database.getSystemSchema().toUpperCase() + ".VIEWS WHERE table_name='%s' AND table_schema='%s' AND table_catalog='%s';"
-                    , example.getName(), schema.getName(), schema.getCatalogName());
+            String query = String.format("SELECT view_definition FROM %s.%s.VIEWS WHERE table_name='%s' AND table_schema='%s' AND table_catalog='%s';",
+                    jdbcSchemaName, database.getSystemSchema().toUpperCase(), example.getName(), schema.getName(), schema.getCatalogName());
 
             List<Map<String, ?>> viewsMetadataRs = Scope.getCurrentScope().getSingleton(ExecutorService.class)
                     .getExecutor("jdbc", database).queryForList(new RawSqlStatement(query));
 
-            String viewDefinition = "";
             if (viewsMetadataRs.isEmpty()) {
                 return null;
             } else {
                 Map<String, ?> row = viewsMetadataRs.get(0);
-                String rawViewName = example.getName(); //(String) row.get("VIEW_DEFINITION");
-                String rawSchemaName = schema.getName(); //StringUtil.trimToNull((String) row.get("TABLE_SCHEM"));
-                String rawCatalogName = schema.getCatalogName(); //StringUtil.trimToNull((String) row.get("TABLE_CAT"));
-                String remarks = null;// (String) row.get("REMARKS");
-
-                viewDefinition = (String) row.get("VIEW_DEFINITION");
+                String rawViewName = example.getName();
+                String rawSchemaName = schema.getName();
+                String rawCatalogName = schema.getCatalogName();
+                String remarks = null;
 
                 View view = (new View()).setName(this.cleanNameFromDatabase(rawViewName, database));
                 view.setRemarks(remarks);
                 CatalogAndSchema schemaFromJdbcInfo = ((AbstractJdbcDatabase) database).getSchemaFromJdbcInfo(rawCatalogName, rawSchemaName);
                 view.setSchema(new Schema(schemaFromJdbcInfo.getCatalogName(), schemaFromJdbcInfo.getSchemaName()));
 
-                //try {
-                String definition = viewDefinition; //database.getViewDefinition(schemaFromJdbcInfo, view.getName());
+                String definition = (String) row.get("VIEW_DEFINITION");
                 if (definition.startsWith("FULL_DEFINITION: ")) {
                     definition = definition.replaceFirst("^FULL_DEFINITION: ", "");
                     view.setContainsFullDefinition(true);


### PR DESCRIPTION
When liquibase.preserveSchemaCase=true, capital and mixed case schema names get quoted which is not valid

Fixes #12

Also updates snapshot generator to keep "not applicable" generators not applicable