### PR TITLE
Use a --changeLogFile argument in the documentation that works with generateChangeLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ logLevel: WARN
 - updating the database schema
 
 ```shell
-liquibase --changeLogFile=changelog.sql update
+liquibase --changeLogFile=changelog.bigquery.sql update
 ```
 
 - generating the schema from current database state


### PR DESCRIPTION
Update the `--changeLogFile` argument in `README.md` to work with the `generateChangeLog` command. If the argument is `changelog.sql`, then `generateChangeLog` will fail with the below error.

```
[2023-05-17 17:36:57] SEVERE [liquibase.integration] Serializing changelog as sql requires a file name in the format *.databaseType.sql. Example: changelog.h2.sql. Passed: changelog.sql
liquibase.exception.CommandExecutionException: java.lang.RuntimeException: java.lang.RuntimeException: liquibase.exception.UnexpectedLiquibaseException: Serializing changelog as sql requires a file name in the format *.databaseType.sql. Example: changelog.h2.sql. Passed: changelog.sql
	at liquibase.command.CommandScope.execute(CommandScope.java:235)
	at liquibase.integration.commandline.CommandRunner.call(CommandRunner.java:55)
	at liquibase.integration.commandline.CommandRunner.call(CommandRunner.java:24)
```