### PR TITLE
DAT-15348 DevOps :: run nightly builds for extensions against core master-snapshot

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,0 +1,13 @@
+# This workflow will build the extension against the latest Liquibase artifact
+name: "Nightly build"
+
+on:
+  schedule:
+    - cron: '0 7 * * 1-5'
+
+jobs:
+    nightly-build:
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.4.1
+      with:
+        nightly: true
+      secrets: inherit


### PR DESCRIPTION
feat(build-nightly.yml): add a workflow to build the extension nightly against the latest Liquibase artifact

The new file `.github/workflows/build-nightly.yml` contains a workflow configuration to build the extension nightly. The workflow is triggered by a cron schedule set to run at 7:00 AM from Monday to Friday. The job `nightly-build` uses the `liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.4.1` action with the `nightly` input set to true. The secrets are inherited from the repository.