### PR TITLE
feat(release-drafter.yml): add release drafter configuration file

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,52 @@
+
+name-template: 'Support for Liquibase BigQuery Extension v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'skipReleaseNotes'
+categories:
+  - title: ':green_book: Notable Changes'
+    labels: 
+      - 'notableChanges'
+  - title: '🚀 New Features'
+    labels:
+      - 'TypeEnhancement'
+      - 'TypeTest'
+  - title: '🐛 Bug Fixes 🛠'
+    labels:
+      - 'TypeBug'
+  - title: '💥 Breaking Changes'
+    labels: 
+      - 'breakingChanges'
+  - title: '🤖 Security Driver and Other Updates'
+    collapse-after: 5
+    labels:
+      - 'sdou'
+      - 'dependencies'
+  - title: '👏 New Contributors'
+    labels:
+      - 'newContributors'  
+       
+  
+change-template: '- (#$NUMBER) $TITLE @$AUTHOR '
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'patch'
+      - 'bugfix'
+      - 'sdou'
+  default: patch
+template: |
+  ## Changes
+  
+  $CHANGES
+
+  **Full Changelog**: https://github.com/liquibase/liquibase-hibernate/compare/$PREVIOUS_TAG...$RESOLVED_VERSION


### PR DESCRIPTION
The release-drafter.yml file is added to the .github directory. This file configures the behavior of the release drafter tool for generating release notes. It includes the following changes:

- Set the name template for the release to 'Support for Liquibase BigQuery Extension v$RESOLVED_VERSION'
- Set the tag template for the release to 'v$RESOLVED_VERSION'
- Exclude labels with the name 'skipReleaseNotes' from being included in the release notes
- Define categories for organizing the release notes, including 'Notable Changes', 'New Features', 'Bug Fixes', 'Breaking Changes', 'Security Driver and Other Updates', and 'New Contributors'
- Specify the change template format for each change in the release notes
- Configure the version resolver to determine the release type based on labels, with 'major', 'minor', and 'patch' as the options
- Define the template for the release notes, including a section for changes and a link to the full changelog on GitHub.