### PR TITLE
DAT-16149 DevOps :: Extensions Release Failing

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.2
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.5
     secrets: inherit
     with:
       extraCommand: mvn install:install-file -Dfile=lib/GoogleBigQueryJDBC42.jar -DgroupId=com.simba.googlebigquery.jdbc -DartifactId=GoogleBigQueryJDBC42 -Dversion=4.2 -Dpackaging=jar

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     nightly-build:
-      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.2
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
       with:
         nightly: true
         extraCommand: mvn install:install-file -Dfile=lib/GoogleBigQueryJDBC42.jar -DgroupId=com.simba.googlebigquery.jdbc -DartifactId=GoogleBigQueryJDBC42 -Dversion=4.2 -Dpackaging=jar

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.2
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.5
     secrets: inherit
     with:
       extraCommand: mvn install:install-file -Dfile=lib/GoogleBigQueryJDBC42.jar -DgroupId=com.simba.googlebigquery.jdbc -DartifactId=GoogleBigQueryJDBC42 -Dversion=4.2 -Dpackaging=jar

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.2
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.5
     secrets: inherit
     with:
       extraCommand: mvn install:install-file -Dfile=lib/GoogleBigQueryJDBC42.jar -DgroupId=com.simba.googlebigquery.jdbc -DartifactId=GoogleBigQueryJDBC42 -Dversion=4.2 -Dpackaging=jar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-test:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.2
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
     secrets: inherit
     with:
       extraCommand: mvn install:install-file -Dfile=lib/GoogleBigQueryJDBC42.jar -DgroupId=com.simba.googlebigquery.jdbc -DartifactId=GoogleBigQueryJDBC42 -Dversion=4.2 -Dpackaging=jar

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,13 @@
         <sonar.tests>src/test/groovy</sonar.tests>
     </properties>
 
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+		<url>https://github.com/liquibase/liquibase-bigquery.git</url>
+		<tag>HEAD</tag>
+	</scm>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
The liquibase/build-logic workflows in the following files have been updated to version v0.5.5:
- .github/workflows/attach-artifact-release.yml
- .github/workflows/build-nightly.yml
- .github/workflows/create-release.yml
- .github/workflows/release-published.yml
- .github/workflows/test.yml

The update includes using the latest version of the workflows to ensure compatibility and take advantage of any bug fixes or improvements.

Additionally, the pom.xml file has been updated to include SCM information for the project. This includes the connection, developer connection, URL, and tag information for the Liquibase BigQuery repository on GitHub.