### PR TITLE
chore(build-nightly.yml): add support for multiple Java versions (11,…

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -13,4 +13,5 @@ jobs:
         nightly: true
         extraCommand: mvn install:install-file -Dfile=lib/GoogleBigQueryJDBC42.jar -DgroupId=com.simba.googlebigquery.jdbc -DartifactId=GoogleBigQueryJDBC42 -Dversion=4.2 -Dpackaging=jar
         os: '["ubuntu-latest"]'
+        java: '[11, 17, 18]'
       secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,4 @@ jobs:
     with:
       extraCommand: mvn install:install-file -Dfile=lib/GoogleBigQueryJDBC42.jar -DgroupId=com.simba.googlebigquery.jdbc -DartifactId=GoogleBigQueryJDBC42 -Dversion=4.2 -Dpackaging=jar
       os: '["ubuntu-latest"]'
+      java: '[11, 17, 18]'


### PR DESCRIPTION
… 17, 18) in the nightly build workflow

chore(test.yml): add support for multiple Java versions (11, 17, 18) in the test workflow