### PR TITLE
fix: Returns raw table name as it was prior to Liquibase 4.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <url>https://github.com/liquibase/liquibase-bigquery</url>
 
     <properties>
-        <liquibase.version>0-SNAPSHOT</liquibase.version>
+        <liquibase.version>master-SNAPSHOT</liquibase.version>
         <spock-core.version>1.3-groovy-2.4</spock-core.version>
         <spock-reports.version>1.8.0</spock-reports.version>
         <groovy-all.version>2.4.17</groovy-all.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <url>https://github.com/liquibase/liquibase-bigquery</url>
 
     <properties>
-        <liquibase.version>4.25.1</liquibase.version>
+        <liquibase.version>0-SNAPSHOT</liquibase.version>
         <spock-core.version>1.3-groovy-2.4</spock-core.version>
         <spock-reports.version>1.8.0</spock-reports.version>
         <groovy-all.version>2.4.17</groovy-all.version>

--- a/src/main/java/liquibase/ext/bigquery/database/BigqueryDatabase.java
+++ b/src/main/java/liquibase/ext/bigquery/database/BigqueryDatabase.java
@@ -166,6 +166,23 @@ public class BigqueryDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
+    public String getDatabaseChangeLogTableName() {
+        if (this.getRawDatabaseChangeLogTableName() != null) {
+            return this.getRawDatabaseChangeLogTableName();
+        }
+
+        return GlobalConfiguration.DATABASECHANGELOG_TABLE_NAME.getCurrentValue();
+    }
+
+    @Override
+    public String getDatabaseChangeLogLockTableName() {
+        if (this.getRawDatabaseChangeLogLockTableName() != null) {
+            return this.getRawDatabaseChangeLogLockTableName();
+        }
+        return GlobalConfiguration.DATABASECHANGELOGLOCK_TABLE_NAME.getCurrentValue();
+    }
+
+    @Override
     public void setLiquibaseSchemaName(String schemaName) {
         this.liquibaseSchemaName = schemaName;
     }
@@ -195,7 +212,6 @@ public class BigqueryDatabase extends AbstractJdbcDatabase {
 
     @Override
     public void setAutoCommit(final boolean b) {
-        return;
     }
 
     @Override


### PR DESCRIPTION
Uses new method that will be available on Liquibase 4.26.0