### PR TITLE
Fix for #143: Let the driver determine the dataset location if non given

### DIFF
--- a/src/main/java/liquibase/ext/bigquery/database/BigqueryConnection.java
+++ b/src/main/java/liquibase/ext/bigquery/database/BigqueryConnection.java
@@ -20,7 +20,6 @@ import static liquibase.ext.bigquery.database.BigqueryDatabase.BIGQUERY_PRIORITY
  */
 
 public class BigqueryConnection extends JdbcConnection {
-    private String location = "";
     private S42Connection con;
 
     public BigqueryConnection() {
@@ -87,7 +86,8 @@ public class BigqueryConnection extends JdbcConnection {
     @Override
     public void open(String url, Driver driverObject, Properties driverProperties) throws DatabaseException {
         if (driverProperties.stringPropertyNames().contains("Location")) {
-            this.location = driverProperties.getProperty("Location");
+            String locationValue = getUrlParamValue(url, "Location");
+            driverProperties.setProperty("Location", locationValue);
         }
 
         Scope.getCurrentScope().getLog(this.getClass()).fine(String.format("Opening connection to %s  driverProperties=%s", url, driverProperties));

--- a/src/main/java/liquibase/ext/bigquery/database/BigqueryConnection.java
+++ b/src/main/java/liquibase/ext/bigquery/database/BigqueryConnection.java
@@ -20,7 +20,7 @@ import static liquibase.ext.bigquery.database.BigqueryDatabase.BIGQUERY_PRIORITY
  */
 
 public class BigqueryConnection extends JdbcConnection {
-    private String location = "US";
+    private String location = "";
     private S42Connection con;
 
     public BigqueryConnection() {
@@ -88,9 +88,6 @@ public class BigqueryConnection extends JdbcConnection {
     public void open(String url, Driver driverObject, Properties driverProperties) throws DatabaseException {
         if (driverProperties.stringPropertyNames().contains("Location")) {
             this.location = driverProperties.getProperty("Location");
-        } else {
-            this.location = getUrlParamValue(url, "Location", "US");
-            driverProperties.setProperty("Location", this.location);
         }
 
         Scope.getCurrentScope().getLog(this.getClass()).fine(String.format("Opening connection to %s  driverProperties=%s", url, driverProperties));


### PR DESCRIPTION
Based on the Google Simba driver documentation, the driver will automatically determine the dataset location.


> The Simba Google BigQuery JDBC Connector supports auto-routing for regional dataset locations. If multiple datasets are available in different geographic regions, the connector automatically queries a dataset in the correct region.

This PR leaves the ability to set the location via the JDBC URL, but removes the else statement setting the default to be the US.