### PR TITLE
[DAT-18244] fixed FK tests, init script, JSONAssert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
-            <version>1.5.2</version>
+            <version>1.5.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,6 @@
             <artifactId>google-cloud-bigquery</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.skyscreamer</groupId>
-            <artifactId>jsonassert</artifactId>
-            <version>1.5.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/src/test/java/liquibase/ext/bigquery/change/BigQueryMergeColumnChangeTest.java
+++ b/src/test/java/liquibase/ext/bigquery/change/BigQueryMergeColumnChangeTest.java
@@ -10,11 +10,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class BigQueryMergeColumnChangeTest {
 

--- a/src/test/resources/liquibase/harness/change/changelogs/bigquery/dropAllForeignKeyConstraints.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/bigquery/dropAllForeignKeyConstraints.xml
@@ -4,15 +4,21 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
-    <changeSet author="oleh" id="1">
+    <changeSet id="1" author="oleh">
         <addForeignKeyConstraint baseColumnNames="author_id"
                                  baseTableName="posts"
                                  constraintName="fk_posts_authors_test"
                                  referencedColumnNames="id"
                                  referencedTableName="authors"/>
-        <rollback>
-            <dropForeignKeyConstraint baseTableName="posts"
-                                      constraintName="fk_posts_authors_test"/>
-        </rollback>
+        <addForeignKeyConstraint baseColumnNames="id"
+                                 baseTableName="posts"
+                                 constraintName="fk_posts_authors_test2"
+                                 referencedColumnNames="id"
+                                 referencedTableName="authors"/>
+        <rollback/>
+    </changeSet>
+    <changeSet id="2" author="oleh">
+        <dropAllForeignKeyConstraints baseTableName="posts"/>
+        <rollback/>
     </changeSet>
 </databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/changelogs/bigquery/dropForeignKey.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/bigquery/dropForeignKey.xml
@@ -4,9 +4,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
-    <changeSet id="1" author="v">
-        <addPrimaryKey tableName="authors" columnNames="id" constraintName="pk_authors"/>
-    </changeSet>
     <changeSet author="oleh" id="1">
         <addForeignKeyConstraint baseColumnNames="author_id"
                                  baseTableName="posts"

--- a/src/test/resources/liquibase/harness/change/changelogs/bigquery/init.txt
+++ b/src/test/resources/liquibase/harness/change/changelogs/bigquery/init.txt
@@ -6,7 +6,8 @@ CREATE TABLE authors (
     last_name STRING NOT NULL,
     email STRING NOT NULL,
     birthdate DATE NOT NULL,
-    added TIMESTAMP NOT NULL
+    added TIMESTAMP NOT NULL,
+    PRIMARY KEY (id) NOT ENFORCED
 );
 
 INSERT INTO authors VALUES (1,'Eileen','Lubowitz','ppaucek@example.org','1991-03-04','2004-05-30 02:08:25');

--- a/src/test/resources/liquibase/harness/change/expectedSql/bigquery/addForeignKey.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/bigquery/addForeignKey.sql
@@ -1,2 +1,1 @@
-ALTER TABLE harness_test_ds.authors ADD PRIMARY KEY (id) NOT ENFORCED
-ALTER TABLE harness_test_ds.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES harness_test_ds.authors (id) NOT ENFORCED
+ALTER TABLE oleh.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES oleh.authors (id) NOT ENFORCED

--- a/src/test/resources/liquibase/harness/change/expectedSql/bigquery/addForeignKey.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/bigquery/addForeignKey.sql
@@ -1,1 +1,1 @@
-ALTER TABLE oleh.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES oleh.authors (id) NOT ENFORCED
+ALTER TABLE harness_test_ds.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES harness_test_ds.authors (id) NOT ENFORCED

--- a/src/test/resources/liquibase/harness/change/expectedSql/bigquery/dropAllForeignKeyConstraints.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/bigquery/dropAllForeignKeyConstraints.sql
@@ -1,1 +1,2 @@
-INVALID TEST -- BigQuery does not support FK
+ALTER TABLE oleh.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES oleh.authors (id) NOT ENFORCED
+ALTER TABLE oleh.posts ADD CONSTRAINT fk_posts_authors_test2 FOREIGN KEY (id) REFERENCES oleh.authors (id) NOT ENFORCED

--- a/src/test/resources/liquibase/harness/change/expectedSql/bigquery/dropAllForeignKeyConstraints.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/bigquery/dropAllForeignKeyConstraints.sql
@@ -1,2 +1,2 @@
-ALTER TABLE oleh.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES oleh.authors (id) NOT ENFORCED
-ALTER TABLE oleh.posts ADD CONSTRAINT fk_posts_authors_test2 FOREIGN KEY (id) REFERENCES oleh.authors (id) NOT ENFORCED
+ALTER TABLE harness_test_ds.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES harness_test_ds.authors (id) NOT ENFORCED
+ALTER TABLE harness_test_ds.posts ADD CONSTRAINT fk_posts_authors_test2 FOREIGN KEY (id) REFERENCES harness_test_ds.authors (id) NOT ENFORCED

--- a/src/test/resources/liquibase/harness/change/expectedSql/bigquery/dropForeignKey.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/bigquery/dropForeignKey.sql
@@ -1,3 +1,2 @@
-ALTER TABLE harness_test_ds.authors ADD PRIMARY KEY (id) NOT ENFORCED
-ALTER TABLE harness_test_ds.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES harness_test_ds.authors (id) NOT ENFORCED
-ALTER TABLE harness_test_ds.posts DROP CONSTRAINT fk_posts_authors_test
+ALTER TABLE oleh.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES oleh.authors (id) NOT ENFORCED
+ALTER TABLE oleh.posts DROP CONSTRAINT fk_posts_authors_test

--- a/src/test/resources/liquibase/harness/change/expectedSql/bigquery/dropForeignKey.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/bigquery/dropForeignKey.sql
@@ -1,2 +1,2 @@
-ALTER TABLE oleh.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES oleh.authors (id) NOT ENFORCED
-ALTER TABLE oleh.posts DROP CONSTRAINT fk_posts_authors_test
+ALTER TABLE harness_test_ds.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES harness_test_ds.authors (id) NOT ENFORCED
+ALTER TABLE harness_test_ds.posts DROP CONSTRAINT fk_posts_authors_test


### PR DESCRIPTION
JSONAssert 1.5.2 broke backward compatibility with java 8, need to update to 1.5.3
[Releases · skyscreamer/JSONassert](https://github.com/skyscreamer/JSONassert/releases)