### PR TITLE
DAT-18247   DevOps :: BigQuery :: PR build checkout step uses main branch instead of feature branch

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -45,6 +45,8 @@ jobs:
         working-directory: src/test/resources/terraform
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       # This action will queue the workflow if another workflow is already running
       - uses: ahmadnassri/action-workflow-queue@v1


### PR DESCRIPTION
https://datical.atlassian.net/browse/DAT-18247

🔧 (test-harness.yml): add support for dynamically setting the ref based on the pull request head sha or the current ref to prevent workflow conflicts