### PR TITLE
add disable-analytics extension to bigquery pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
             <version>${jsonassert.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.liquibase.ext</groupId>
+            <artifactId>liquibase-disable-analytics</artifactId>
+            <version>1.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
chore: as we are not able to upgrade parent pom as it conflicts with junit4, add disable-analytics extension directly to bigquery pom