### PR TITLE
Escape schema name in query DAT-18828

### DIFF
--- a/src/main/java/liquibase/ext/bigquery/diff/output/changelog/core/BigQueryChangedTableChangeGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/diff/output/changelog/core/BigQueryChangedTableChangeGenerator.java
@@ -18,6 +18,9 @@ public class BigQueryChangedTableChangeGenerator extends ChangedTableChangeGener
     @Override
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
         int priority = super.getPriority(objectType, database);
+        if (priority == PRIORITY_NONE) {
+            return priority;
+        }
         if (database instanceof BigQueryDatabase) {
             priority += PRIORITY_DATABASE;
         }

--- a/src/main/java/liquibase/ext/bigquery/diff/output/changelog/core/BigQueryChangedTableChangeGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/diff/output/changelog/core/BigQueryChangedTableChangeGenerator.java
@@ -17,13 +17,14 @@ public class BigQueryChangedTableChangeGenerator extends ChangedTableChangeGener
 
     @Override
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (! (database instanceof BigQueryDatabase)) {
+            return PRIORITY_NONE;
+        }
         int priority = super.getPriority(objectType, database);
         if (priority == PRIORITY_NONE) {
             return priority;
         }
-        if (database instanceof BigQueryDatabase) {
-            priority += PRIORITY_DATABASE;
-        }
+        priority += PRIORITY_DATABASE;
         return priority;
     }
 

--- a/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryPrimaryKeySnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryPrimaryKeySnapshotGenerator.java
@@ -44,7 +44,7 @@ public class BigQueryPrimaryKeySnapshotGenerator extends PrimaryKeySnapshotGener
         PrimaryKey returnKey = null;
 
         String keyColumnUsageStatement = String.format("SELECT * FROM %s.INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE CONSTRAINT_NAME = ?",
-                example.getSchema().getName());
+                database.escapeObjectName(example.getSchema().getName(), Schema.class));
         Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
         List<Map<String, ?>> maps = executor.queryForList(new RawParameterizedSqlStatement(keyColumnUsageStatement, example.getName()));
         String columnName;

--- a/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryPrimaryKeySnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryPrimaryKeySnapshotGenerator.java
@@ -84,7 +84,7 @@ public class BigQueryPrimaryKeySnapshotGenerator extends PrimaryKeySnapshotGener
 
             Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
             String tableConstraintsStatement = String.format("SELECT * FROM %s.INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE " +
-                    "CONSTRAINT_TYPE = 'PRIMARY KEY' AND table_name = ?", table.getSchema().getName());
+                    "CONSTRAINT_TYPE = 'PRIMARY KEY' AND table_name = ?", database.escapeObjectName(table.getSchema().getName(), Schema.class));
             List<Map<String, ?>> maps = executor.queryForList(new RawParameterizedSqlStatement(tableConstraintsStatement, table.getName()));
 
             for (Map<String, ?> map : maps) {


### PR DESCRIPTION
There was an unescaped schema name in a query, which caused a 400 error in the BigQuery POST.