### PR TITLE
DAT-19388 [DevOps] Fix terraform executable in GH

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -48,6 +48,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
       # This action will queue the workflow if another workflow is already running
       - uses: ahmadnassri/action-workflow-queue@v1
         with:
@@ -219,6 +225,12 @@ jobs:
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
 
       - name: set GCP project
         id: config_project


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/test-harness.yml` file to set up Terraform in the workflow jobs. The most important changes are:

* Added a step to set up Terraform using the `hashicorp/setup-terraform@v3` action with Terraform version "1.5.7" and `terraform_wrapper` set to false. This step was added in two places within the `jobs:` section. [[1]](diffhunk://#diff-2265ea93df1127b2e8796b98549b237cc84aaa6f4c36674b480d9c8292ec5b30R51-R56) [[2]](diffhunk://#diff-2265ea93df1127b2e8796b98549b237cc84aaa6f4c36674b480d9c8292ec5b30R229-R234)