### PR TITLE
🔧 update actions/upload-artifact version to v4

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -187,7 +187,7 @@ jobs:
           fail-on-error: false # Set fail-on-error to false to show report even if it has failed tests
 
       - name: Archive Bigquery Database Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bigquery-test-results
           path: target/surefire-reports


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/test-harness.yml` file to use a newer version of the `upload-artifact` action.

* [`.github/workflows/test-harness.yml`](diffhunk://#diff-2265ea93df1127b2e8796b98549b237cc84aaa6f4c36674b480d9c8292ec5b30L190-R190): Updated the `upload-artifact` action from version `v3` to `v4` to ensure compatibility with the latest features and improvements.