### PR TITLE
fix: add missing replaces method for ViewSnapshot Generator

### DIFF
--- a/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryViewSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/bigquery/snapshot/jvm/BigQueryViewSnapshotGenerator.java
@@ -8,6 +8,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.ext.bigquery.database.BigQueryDatabase;
 import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.snapshot.jvm.ViewSnapshotGenerator;
 import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.DatabaseObject;
@@ -85,4 +86,8 @@ public class BigQueryViewSnapshotGenerator extends ViewSnapshotGenerator {
         }
     }
 
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{ViewSnapshotGenerator.class};
+    }
 }


### PR DESCRIPTION
https://github.com/liquibase/liquibase/pull/5775/ was merged and fixed a bug where some snapshot generators were not being called.
But it also highlighted one issue at least in one OSS extension: if then extension replaces a core generator but is not implementing the replaces method, both generators may be invoked now.

This PR implements the missing replaces method.