### PR TITLE
DAT-20197 REPO: liquibase-bigquery

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -25,7 +25,7 @@ jobs:
         id: get_draft_release_id
         run: |
           release_name="v0.0.${{ github.run_number }}"
-          response=$(curl -s -H "Authorization: token ${{ secrets.BOT_TOKEN }}" \
+          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                           -H "Accept: application/vnd.github.v3+json" \
                           "https://api.github.com/repos/${{ github.repository }}/releases")
           draft_release=$(echo "$response" | jq -r --arg name "$release_name" '.[] | select(.name == $name and .draft == true)')
@@ -70,7 +70,7 @@ jobs:
       - name: Delete the dry-run draft release
         if: always()
         run: |
-          curl -X DELETE -H "Authorization: token ${{ secrets.BOT_TOKEN }}" \
+          curl -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                 -H "Accept: application/vnd.github.v3+json" \
                 "https://api.github.com/repos/${{ github.repository }}/releases/${{ needs.dry-run-get-draft-release.outputs.dry_run_release_id }}"
                 

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -156,12 +156,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               }
             ]
 


### PR DESCRIPTION
This pull request makes updates to GitHub Actions workflows to improve the security and consistency of secret usage. The changes primarily involve replacing older secret tokens with more appropriate or updated ones.

### Updates to secret usage in workflows:

* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL28-R28): Replaced `BOT_TOKEN` with `GITHUB_TOKEN` for authorization in API calls, ensuring better alignment with GitHub's recommended practices. [[1]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL28-R28) [[2]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL73-R73)
* [`.github/workflows/test-harness.yml`](diffhunk://#diff-2265ea93df1127b2e8796b98549b237cc84aaa6f4c36674b480d9c8292ec5b30L159-R164): Updated the `password` field for `liquibot` credentials to use `LIQUIBOT_PAT_GPM_ACCESS` instead of `LIQUIBOT_PAT`, likely reflecting a more specific or updated secret for accessing resources.