### PR TITLE
fix: add matrix suffix to test artifact names to prevent upload conflicts

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Archive Bigquery Database Test Results
         uses: actions/upload-artifact@v4
         with:
-          name: bigquery-test-results
+          name: bigquery-test-results-${{ matrix.liquibase-support-level }}
           path: target/surefire-reports
 
       - name: Test Summary

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -186,10 +186,15 @@ jobs:
           reporter: java-junit # Set the reporter to use
           fail-on-error: false # Set fail-on-error to false to show report even if it has failed tests
 
+      - name: Debug Matrix Value
+        run: |
+          echo "Matrix level: ${{ matrix['liquibase-support-level'] }}"
+          echo "Artifact name will be: bigquery-test-results-${{ matrix['liquibase-support-level'] }}"
+
       - name: Archive Bigquery Database Test Results
         uses: actions/upload-artifact@v4
         with:
-          name: bigquery-test-results-${{ matrix.liquibase-support-level }}
+          name: bigquery-test-results-${{ matrix['liquibase-support-level'] }}
           path: target/surefire-reports
 
       - name: Test Summary


### PR DESCRIPTION
The test-harness workflow runs tests for multiple support levels in parallel (Contributed, Foundational, Advanced) but was uploading all artifacts with the same name 'bigquery-test-results', causing 409 Conflict errors. 

This change appends the matrix test level to each artifact name, ensuring unique names and preventing build failures.