### PR TITLE
Fix nightly build workflow permissions

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pull-requests: write
   packages: read
+  id-token: write
 
 jobs:
   nightly-build:


### PR DESCRIPTION
## Summary
- Adds missing `id-token: write` permission to the nightly build workflow
- Fixes the startup_failure that has been occurring since July 18, 2025

## Background
The nightly build workflow has been failing with `startup_failure` since July 18, 2025. The issue is that the reusable workflow `liquibase/build-logic/.github/workflows/os-extension-test.yml` was updated to use AWS Secrets Manager with OIDC authentication, which requires the `id-token: write` permission.

## Changes
Added the missing permission to `.github/workflows/build-nightly.yml`:
```yaml
permissions:
  contents: read
  pull-requests: write
  packages: read
  id-token: write  # Added this line
```

## Test plan
- [x] Verified the permission is present in the workflow file
- [ ] Once merged, the nightly build should run successfully

🤖 Generated with [Claude Code](https://claude.ai/code)