### PR TITLE
DAT-20766   DevOps :: testharness.yml workflow failing

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -2,24 +2,23 @@ name: Liquibase Test Harness for BigQuery
 on:
   pull_request_target:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'main'
-      - 'master'
+      - "main"
+      - "master"
     paths:
-      - 'src/test/resources/terraform/**'
+      - "src/test/resources/terraform/**"
   workflow_dispatch:
 
 env:
-  tf_version: 'latest'
+  tf_version: "latest"
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-
   authorize:
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
@@ -30,8 +29,8 @@ jobs:
     needs: authorize
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
 
     defaults:
       run:
@@ -40,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      
+
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -54,7 +53,7 @@ jobs:
           secret-ids: |
             ,/vault/liquibase
           parse-json-secrets: true
-       
+
       - name: Setup Google credentials
         uses: liquibase/build-logic/.github/actions/setup-google-credentials@main
 
@@ -110,7 +109,7 @@ jobs:
         #if: ${{ github.event_name == 'push' }}
         run: |
           spacectl stack set-current-commit --id liquibase-bigquery-testharness-tests --sha ${{ github.sha }}
-          spacectl stack deploy --id liquibase-bigquery-testharness-tests --auto-confirm 
+          spacectl stack deploy --id liquibase-bigquery-testharness-tests --auto-confirm
 
   test:
     name: Run Test Harness
@@ -122,8 +121,8 @@ jobs:
         liquibase-support-level: [Contributed, Foundational, Advanced] # Define the different test levels to run
       fail-fast: false # Set fail-fast to false to run all test levels even if some of them fail
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
       checks: write
 
     steps:
@@ -145,6 +144,9 @@ jobs:
           secret-ids: |
             ,/vault/liquibase
           parse-json-secrets: true
+
+      - name: Setup Google credentials
+        uses: liquibase/build-logic/.github/actions/setup-google-credentials@main
 
         #look for dependencies in maven
       - name: maven-settings-xml-action
@@ -221,18 +223,17 @@ jobs:
           paths: "target/surefire-reports/**/TEST-*.xml"
         if: always()
 
-
   destroy:
     runs-on: ubuntu-latest
-    needs: [setup,test]
+    needs: [setup, test]
 
     defaults:
       run:
         working-directory: src/test/resources/terraform
 
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes several improvements to the `.github/workflows/test-harness.yml` file, focusing on consistency, permissions, and integration with Google credentials. The main changes are standardizing YAML formatting, updating permissions blocks, and adding a step to set up Google credentials for the workflow.

**Formatting and permissions updates:**

* Standardized the use of double quotes for all YAML strings, including branch names, paths, and permission values, to improve consistency and readability. [[1]](diffhunk://#diff-2265ea93df1127b2e8796b98549b237cc84aaa6f4c36674b480d9c8292ec5b30L5-L22) [[2]](diffhunk://#diff-2265ea93df1127b2e8796b98549b237cc84aaa6f4c36674b480d9c8292ec5b30L33-R33) [[3]](diffhunk://#diff-2265ea93df1127b2e8796b98549b237cc84aaa6f4c36674b480d9c8292ec5b30L125-R125) [[4]](diffhunk://#diff-2265ea93df1127b2e8796b98549b237cc84aaa6f4c36674b480d9c8292ec5b30L234-R236)

**Integration improvements:**

* Added a step to set up Google credentials using the `liquibase/build-logic/.github/actions/setup-google-credentials@main` action, which helps with authentication for Google services in the workflow.

**Workflow structure:**

* Minor adjustment to job separation for clarity, by removing an unnecessary blank line before the `destroy` job.