### PR TITLE
refactor(ci): replace archived whelk-io with build-logic setup-maven-settings [DAT-22915]

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -149,47 +149,11 @@ jobs:
         uses: liquibase/build-logic/.github/actions/setup-google-credentials@main
 
         #look for dependencies in maven
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
-          repositories: |
-            [
-              {
-                "id": "liquibase",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "false"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              },
-              {
-                "id": "liquibase-pro",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-                "releases": {
-                  "enabled": "false"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
-            ]
-          servers: |
-            [
-              {
-                "id": "liquibase-pro",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              },
-              {
-                "id": "liquibase",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
-            ]
+          gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
+          releases-enabled: 'false'
 
       - name: Run ${{ matrix.liquibase-support-level }} Liquibase Test Harness # Run the Liquibase test harness at each test level
         env:


### PR DESCRIPTION
## Summary

Replace the single `whelk-io/maven-settings-xml-action` call site in `.github/workflows/test-harness.yml` with the new first-party composite action [`liquibase/build-logic/.github/actions/setup-maven-settings`](https://github.com/liquibase/build-logic/pull/557).

Jira: [DAT-22915](https://datical.atlassian.net/browse/DAT-22915)

## Why

`whelk-io/maven-settings-xml-action` was **archived 2026-01-02** and flagged during the DAT-22654 supply-chain audit. Parent ticket DAT-22915 covers the full org rollout (63 uses / 49 workflow files).

## What changed

| Before | After |
|---|---|
| ~40-line inline JSON block passed to archived `whelk-io/...@v22` | 4-line call to `liquibase/build-logic/.github/actions/setup-maven-settings@main` |

Simple-mode invocation, behavior preserved exactly:
- **Repositories:** `liquibase` + `liquibase-pro` GPM
- **Servers:** both `liquibot` + `${{ env.LIQUIBOT_PAT_GPM_ACCESS }}`
- **`releases-enabled: 'false'`** — preserves the previous `"releases": {"enabled": "false"}` (snapshots-only)

## Blocked by

🚧 [**liquibase/build-logic#557**](https://github.com/liquibase/build-logic/pull/557) must merge first — this PR uses `@main` which won't resolve until the composite action lands on build-logic's main branch. That's why this PR is a **draft**.

## Test plan

- [x] YAML parses cleanly
- [x] No remaining `whelk-io` references
- [x] `${{ env.LIQUIBOT_PAT_GPM_ACCESS }}` still flows from the pre-existing vault step unchanged
- [ ] CI green post-merge of liquibase/build-logic#557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-22915]: https://datical.atlassian.net/browse/DAT-22915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ